### PR TITLE
try/catch on OneLocaleFilter

### DIFF
--- a/Doctrine/ORM/Filter/OneLocaleFilter.php
+++ b/Doctrine/ORM/Filter/OneLocaleFilter.php
@@ -13,8 +13,11 @@ class OneLocaleFilter extends SQLFilter
         if (!$targetEntity->reflClass->implementsInterface('\A2lix\I18nDoctrineBundle\Doctrine\Interfaces\OneLocaleInterface')) {
             return "";
         }
-
-        return $targetTableAlias .'.locale = '. $this->getParameter('locale');
+        try {
+            return $targetTableAlias .'.locale = '. $this->getParameter('locale');
+        } catch (\InvalidArgumentException $e) {
+            return '';
+        }
     }
 
 }


### PR DESCRIPTION
Without this try/catch, if you use I18nDoctrineBundle with Sluggable, you cannot set slug on Translation table. Here is a stack trace with previous implementation:

```
InvalidArgumentException: Parameter 'locale' does not exist.

myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Filter/SQLFilter.php:104
myproject/vendor/a2lix/i18n-doctrine-bundle/A2lix/I18nDoctrineBundle/Doctrine/ORM/Filter/OneLocaleFilter.php:17
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query/SqlWalker.php:504
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query/SqlWalker.php:1759
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query/SqlWalker.php:522
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php:42
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query/SqlWalker.php:277
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:390
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:266
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:278
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/AbstractQuery.php:967
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/AbstractQuery.php:922
myproject/vendor/gedmo/doctrine-extensions/lib/Gedmo/Sluggable/Mapping/Event/Adapter/ORM.php:57
myproject/vendor/gedmo/doctrine-extensions/lib/Gedmo/Sluggable/SluggableListener.php:426
myproject/vendor/gedmo/doctrine-extensions/lib/Gedmo/Sluggable/SluggableListener.php:375
myproject/vendor/gedmo/doctrine-extensions/lib/Gedmo/Sluggable/SluggableListener.php:212
myproject/vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php:61
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:3323
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:338
myproject/vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php:355
myproject/myScriptSettingASlug.php:1
```
